### PR TITLE
fix(medienkompetenz): let editors resize embedded images

### DIFF
--- a/apps/definitions/forms.py
+++ b/apps/definitions/forms.py
@@ -1,4 +1,5 @@
 import bleach
+from bleach.css_sanitizer import CSSSanitizer
 from django import forms
 from django.utils.html import strip_tags
 from django.utils.translation import gettext_lazy as _
@@ -30,6 +31,15 @@ _ALLOWED_ATTRS = {
     'figcaption': ['class'],
 }
 
+# Allowlist for the img `style` attribute so bleach actually sanitizes inline
+# CSS (sizing) instead of dropping it and emitting a NoCssSanitizerWarning.
+_CSS_SANITIZER = CSSSanitizer(
+    allowed_css_properties=[
+        'width', 'height',
+        'float', 'margin', 'margin-left', 'margin-right',
+    ]
+)
+
 
 class DefinitionForm(forms.ModelForm):
     """Create/edit form for a Definition, with rich text explanations and free-text tags."""
@@ -60,6 +70,7 @@ class DefinitionForm(forms.ModelForm):
             raw or '',
             tags=_ALLOWED_TAGS,
             attributes=_ALLOWED_ATTRS,
+            css_sanitizer=_CSS_SANITIZER,
             strip=True,
         )
 

--- a/apps/definitions/tests/test_forms.py
+++ b/apps/definitions/tests/test_forms.py
@@ -24,6 +24,21 @@ class DefinitionFormTests(TestCase):
         self.assertTrue(form.is_valid(), form.errors)
         self.assertEqual(form.parsed_tags(), ['geschichte', 'antisemitismus'])
 
+    def test_image_style_is_css_sanitized(self):
+        # Allowed sizing props survive; disallowed props are stripped without a
+        # NoCssSanitizerWarning.
+        form = DefinitionForm(data={
+            'term': 'Bildbegriff',
+            'simple_explanation': '<p>Text</p><img src="/media/x.png" '
+                                  'style="width: 200px; position: fixed;">',
+            'formal_explanation': 'Formale Erklärung.',
+            'tags': '',
+        })
+        self.assertTrue(form.is_valid(), form.errors)
+        cleaned = form.cleaned_data['simple_explanation']
+        self.assertIn('width: 200px', cleaned)
+        self.assertNotIn('position', cleaned)
+
     def test_both_explanations_required(self):
         form = DefinitionForm(data={
             'term': 'Begriff',

--- a/apps/medienkompetenz/forms.py
+++ b/apps/medienkompetenz/forms.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 from typing import Any
 
 import bleach
+from bleach.css_sanitizer import CSSSanitizer
 from django import forms
 from django.utils.html import strip_tags
 from django.utils.translation import gettext_lazy as _
@@ -43,7 +44,7 @@ _ALLOWED_ATTRS = {
     'ol': ['class', 'start'],
     'ul': ['class'],
     'span': ['class'],
-    'img': ['src', 'alt', 'width', 'height', 'class'],
+    'img': ['src', 'alt', 'width', 'height', 'class', 'style'],
     'iframe': [
         'src', 'class', 'width', 'height',
         'frameborder', 'allowfullscreen', 'allow',
@@ -54,11 +55,24 @@ _ALLOWED_ATTRS = {
 }
 
 
+# Sanitize the `style` attribute rather than dropping it: the Quill image-resize
+# module stores the dragged dimensions as inline `width`/`height`, so an
+# allowlisted CSS sanitizer is what lets editors resize images and have that
+# size survive save. Anything outside this property list is stripped.
+_CSS_SANITIZER = CSSSanitizer(
+    allowed_css_properties=[
+        'width', 'height',
+        'float', 'margin', 'margin-left', 'margin-right',
+    ]
+)
+
+
 def _sanitize(raw: str) -> str:
     return bleach.clean(
         raw or '',
         tags=_ALLOWED_TAGS,
         attributes=_ALLOWED_ATTRS,
+        css_sanitizer=_CSS_SANITIZER,
         strip=True,
     )
 

--- a/apps/medienkompetenz/tests/test_forms.py
+++ b/apps/medienkompetenz/tests/test_forms.py
@@ -34,6 +34,34 @@ class ArticleFormSanitizeTest(TestCase):
         self.assertFalse(form.is_valid())
         self.assertIn('body', form.errors)
 
+    def test_preserves_image_resize_width_style(self):
+        # The Quill image-resize module stores the dragged size as an inline
+        # width style; it must survive sanitization so editors can size images.
+        form = ArticleForm(data={
+            'title': 'Test',
+            'lead': '',
+            'body': '<p>Bild:</p><p><img src="/media/x.png" style="width: 320px;"></p>',
+            'references': '',
+            'is_published': True,
+            'tags': '',
+        })
+        self.assertTrue(form.is_valid(), form.errors)
+        self.assertIn('width: 320px', form.cleaned_data['body'])
+
+    def test_strips_disallowed_style_property_from_image(self):
+        form = ArticleForm(data={
+            'title': 'Test',
+            'lead': '',
+            'body': '<p>Bild:</p><p><img src="/media/x.png" style="position: fixed; width: 50px;"></p>',
+            'references': '',
+            'is_published': True,
+            'tags': '',
+        })
+        self.assertTrue(form.is_valid(), form.errors)
+        body = form.cleaned_data['body']
+        self.assertNotIn('position', body)
+        self.assertIn('width: 50px', body)
+
 
 class AiImageQuizFormTest(TestCase):
     def test_valid_items_produce_structured_data(self):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ dependencies = [
     "gunicorn>=23.0",
     "whitenoise>=6.8",
     "django-taggit>=6.0",
-    "bleach>=6.0",
+    "bleach[css]>=6.0",
     "pillow>=12.2.0",
 ]
 

--- a/templates/medienkompetenz/article_form.html
+++ b/templates/medienkompetenz/article_form.html
@@ -311,6 +311,9 @@
 {% block extra_js %}
 <link href="https://cdn.quilljs.com/1.3.7/quill.snow.css" rel="stylesheet">
 <script src="https://cdn.quilljs.com/1.3.7/quill.min.js"></script>
+{# Drag-to-resize handles for embedded images. Stores the chosen size as an
+   inline width/height style, which the server-side CSS sanitizer preserves. #}
+<script src="https://cdn.jsdelivr.net/npm/quill-image-resize-module@3.0.0/image-resize.min.js"></script>
 
 <style>
     .ql-container.ql-snow { border: none !important; }
@@ -345,9 +348,20 @@
         });
     }
 
+    // Register the image-resize module once, if the CDN script loaded. Guarded
+    // so the editor still works (minus resizing) should the CDN be unreachable.
+    const hasImageResize = typeof window.ImageResize !== 'undefined';
+    if (hasImageResize) {
+        Quill.register('modules/imageResize', window.ImageResize.default || window.ImageResize);
+    }
+
     function initQuill(editorId, toolbarId, hiddenId, withImage) {
+        const modules = { toolbar: '#' + toolbarId };
+        if (withImage && hasImageResize) {
+            modules.imageResize = { modules: ['Resize', 'DisplaySize'] };
+        }
         const quill = new Quill('#' + editorId, {
-            modules: { toolbar: '#' + toolbarId },
+            modules: modules,
             theme: 'snow',
         });
 

--- a/templates/medienkompetenz/blocks/_ai_image_quiz.html
+++ b/templates/medienkompetenz/blocks/_ai_image_quiz.html
@@ -17,7 +17,7 @@
         <div x-data="{ guess: null }" class="bg-white/60 rounded-lg overflow-hidden border border-forest/10 flex flex-col">
             <div class="aspect-[4/3] bg-white/40 overflow-hidden">
                 {% if item.image %}
-                <img src="{{ item.image }}" alt="" class="w-full h-full object-cover">
+                <img src="{{ item.image }}" alt="" class="w-full h-full object-contain">
                 {% endif %}
             </div>
             <div class="p-4 flex flex-col gap-3 flex-1">

--- a/uv.lock
+++ b/uv.lock
@@ -7,7 +7,7 @@ name = "aenderung-durch-austausch"
 version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
-    { name = "bleach" },
+    { name = "bleach", extra = ["css"] },
     { name = "django" },
     { name = "django-environ" },
     { name = "django-taggit" },
@@ -25,7 +25,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "bleach", specifier = ">=6.0" },
+    { name = "bleach", extras = ["css"], specifier = ">=6.0" },
     { name = "django", specifier = ">=5.2,<6.0" },
     { name = "django-environ", specifier = ">=0.11" },
     { name = "django-taggit", specifier = ">=6.0" },
@@ -60,6 +60,11 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/07/18/3c8523962314be6bf4c8989c79ad9531c825210dd13a8669f6b84336e8bd/bleach-6.3.0.tar.gz", hash = "sha256:6f3b91b1c0a02bb9a78b5a454c92506aa0fdf197e1d5e114d2e00c6f64306d22", size = 203533, upload-time = "2025-10-27T17:57:39.211Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cd/3a/577b549de0cc09d95f11087ee63c739bba856cd3952697eec4c4bb91350a/bleach-6.3.0-py3-none-any.whl", hash = "sha256:fe10ec77c93ddf3d13a73b035abaac7a9f5e436513864ccdad516693213c65d6", size = 164437, upload-time = "2025-10-27T17:57:37.538Z" },
+]
+
+[package.optional-dependencies]
+css = [
+    { name = "tinycss2" },
 ]
 
 [[package]]
@@ -349,6 +354,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/90/76/437d71068094df0726366574cf3432a4ed754217b436eb7429415cf2d480/sqlparse-0.5.5.tar.gz", hash = "sha256:e20d4a9b0b8585fdf63b10d30066c7c94c5d7a7ec47c889a2d83a3caa93ff28e", size = 120815, upload-time = "2025-12-19T07:17:45.073Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/49/4b/359f28a903c13438ef59ebeee215fb25da53066db67b305c125f1c6d2a25/sqlparse-0.5.5-py3-none-any.whl", hash = "sha256:12a08b3bf3eec877c519589833aed092e2444e68240a3577e8e26148acc7b1ba", size = 46138, upload-time = "2025-12-19T07:17:46.573Z" },
+]
+
+[[package]]
+name = "tinycss2"
+version = "1.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "webencodings" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7a/fd/7a5ee21fd08ff70d3d33a5781c255cbe779659bd03278feb98b19ee550f4/tinycss2-1.4.0.tar.gz", hash = "sha256:10c0972f6fc0fbee87c3edb76549357415e94548c1ae10ebccdea16fb404a9b7", size = 87085, upload-time = "2024-10-24T14:58:29.895Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e6/34/ebdc18bae6aa14fbee1a08b63c015c72b64868ff7dae68808ab500c492e2/tinycss2-1.4.0-py3-none-any.whl", hash = "sha256:3a49cf47b7675da0b15d0c6e1df8df4ebd96e9394bb905a5775adb0d884c5289", size = 26610, upload-time = "2024-10-24T14:58:28.029Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Images embedded via the Quill editor came in at their intrinsic size with no way to enlarge them: Quill 1.3.7 ships no resize handles, and commit 74cfb0f had dropped the img `style` attribute from the bleach allowlist, so any inline width would not survive save either.

- Add the quill-image-resize-module (drag handles) to the body editor; it stores the chosen size as an inline width/height style.
- Re-allow the img `style` attribute but sanitize it with bleach's CSSSanitizer (width/height/float/margin only), resolving the original NoCssSanitizerWarning that motivated dropping it. Same fix applied to apps.definitions.forms, which still allowed img style without a css_sanitizer (silences the warning there too).
- KI-Bild-Quiz: switch the thumbnail from object-cover to object-contain so the full image is shown instead of a centre crop.
- Add bleach[css] extra (pulls tinycss2) and regression tests.

<!-- preview-deployment:start -->
### Dokploy Preview Deployment


| Name       | Status       | Preview                             | Updated (UTC)         |
|------------|--------------|-------------------------------------|-----------------------|
| ÄdA Web Staging  | ✅ Done | [Preview URL](https://preview-aeda-web-staging-iduicr-5b1lm9.aenderung-durch-austausch.de) | 2026-07-01T17:37:58.572Z |

<!-- preview-deployment:end -->